### PR TITLE
Cloudwatch metrics for Beanstalk Instances and Environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ The following resources will be created:
 | autoscaling\_health\_check\_grace\_period | The length of time that Auto Scaling waits before checking an instance's health status. The grace period begins when an instance comes into service | `number` | `300` | no |
 | certificate\_arn | n/a | `any` | n/a | yes |
 | cloudwatch\_logs\_retention | Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. | `number` | `120` | no |
-| coudwatch\_environment\_metrics | Environment metrics to be collected from beanstalk to cloudwatch | `map` | `{}` | no |
-| coudwatch\_instance\_metrics | Instance metrics to be collected from beanstalk to cloudwatch | `map` | `{}` | no |
+| coudwatch\_environment\_metrics | Environment metrics to be collected from beanstalk to cloudwatch | `map(string)` | `{}` | no |
+| coudwatch\_instance\_metrics | Instance metrics to be collected from beanstalk to cloudwatch | `map(string)` | `{}` | no |
 | eb\_application\_name | EB application name (empty value will create an application) | `string` | `""` | no |
 | eb\_solution\_stack\_name | Stack name passed to ElasticBeanstalk | `any` | n/a | yes |
 | enable\_schedule | Enables schedule to shut down and start up instances outside business hours | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ The following resources will be created:
 | autoscaling\_health\_check\_grace\_period | The length of time that Auto Scaling waits before checking an instance's health status. The grace period begins when an instance comes into service | `number` | `300` | no |
 | certificate\_arn | n/a | `any` | n/a | yes |
 | cloudwatch\_logs\_retention | Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. | `number` | `120` | no |
-| coudwatch\_environment\_metrics | Environment metrics to be collected from beanstalk to cloudwatch | `map(string)` | `{}` | no |
-| coudwatch\_instance\_metrics | Instance metrics to be collected from beanstalk to cloudwatch | `map(string)` | `{}` | no |
+| coudwatch\_environment\_metrics | Environment metrics to be collected from beanstalk to cloudwatch | `map(number)` | `{}` | no |
+| coudwatch\_instance\_metrics | Instance metrics to be collected from beanstalk to cloudwatch | `map(number)` | `{}` | no |
 | eb\_application\_name | EB application name (empty value will create an application) | `string` | `""` | no |
 | eb\_solution\_stack\_name | Stack name passed to ElasticBeanstalk | `any` | n/a | yes |
 | enable\_schedule | Enables schedule to shut down and start up instances outside business hours | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The following resources will be created:
 | autoscaling\_health\_check\_grace\_period | The length of time that Auto Scaling waits before checking an instance's health status. The grace period begins when an instance comes into service | `number` | `300` | no |
 | certificate\_arn | n/a | `any` | n/a | yes |
 | cloudwatch\_logs\_retention | Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. | `number` | `120` | no |
+| coudwatch\_environment\_metrics | Environment metrics to be collected from beanstalk to cloudwatch | `map` | `{}` | no |
+| coudwatch\_instance\_metrics | Instance metrics to be collected from beanstalk to cloudwatch | `map` | `{}` | no |
 | eb\_application\_name | EB application name (empty value will create an application) | `string` | `""` | no |
 | eb\_solution\_stack\_name | Stack name passed to ElasticBeanstalk | `any` | n/a | yes |
 | enable\_schedule | Enables schedule to shut down and start up instances outside business hours | `bool` | `false` | no |

--- a/_variables.tf
+++ b/_variables.tf
@@ -184,10 +184,12 @@ variable "ignore_iam_account_alias" {
   description = "Disables data source for iam_account_alias used on cloudwatch alarms"
 }
 variable "coudwatch_environment_metrics" {
-  default  = {}
+  type        = map(string)
+  default     = {}
   description = "Environment metrics to be collected from beanstalk to cloudwatch"
 }
 variable "coudwatch_instance_metrics" {
-  default  = {}
+  type        = map(string)
+  default     = {}
   description = "Instance metrics to be collected from beanstalk to cloudwatch"
 }

--- a/_variables.tf
+++ b/_variables.tf
@@ -184,12 +184,12 @@ variable "ignore_iam_account_alias" {
   description = "Disables data source for iam_account_alias used on cloudwatch alarms"
 }
 variable "coudwatch_environment_metrics" {
-  type        = map(string)
+  type        = map(number)
   default     = {}
   description = "Environment metrics to be collected from beanstalk to cloudwatch"
 }
 variable "coudwatch_instance_metrics" {
-  type        = map(string)
+  type        = map(number)
   default     = {}
   description = "Instance metrics to be collected from beanstalk to cloudwatch"
 }

--- a/_variables.tf
+++ b/_variables.tf
@@ -183,3 +183,11 @@ variable "ignore_iam_account_alias" {
   default     = false
   description = "Disables data source for iam_account_alias used on cloudwatch alarms"
 }
+variable "coudwatch_environment_metrics" {
+  default  = {}
+  description = "Environment metrics to be collected from beanstalk to cloudwatch"
+}
+variable "coudwatch_instance_metrics" {
+  default  = {}
+  description = "Instance metrics to be collected from beanstalk to cloudwatch"
+}

--- a/eb.tf
+++ b/eb.tf
@@ -66,73 +66,73 @@ locals {
       namespace = "aws:autoscaling:trigger"
       value     = "5"
     },
-    # {
-    #   name      = "ConfigDocument"
-    #   namespace = "aws:elasticbeanstalk:healthreporting:system"
-    #   value = jsonencode(
-    #     {
-    #       CloudWatchMetrics = {
-    #         Environment = {
-    #           ApplicationLatencyP10     = null
-    #           ApplicationLatencyP50     = null
-    #           ApplicationLatencyP75     = null
-    #           ApplicationLatencyP85     = null
-    #           ApplicationLatencyP90     = null
-    #           ApplicationLatencyP95     = null
-    #           ApplicationLatencyP99     = null
-    #           "ApplicationLatencyP99.9" = null
-    #           ApplicationRequests2xx    = null
-    #           ApplicationRequests3xx    = null
-    #           ApplicationRequests4xx    = null
-    #           ApplicationRequests5xx    = null
-    #           ApplicationRequestsTotal  = null
-    #           InstancesDegraded         = null
-    #           InstancesInfo             = null
-    #           InstancesNoData           = null
-    #           InstancesOk               = null
-    #           InstancesPending          = null
-    #           InstancesSevere           = null
-    #           InstancesUnknown          = null
-    #           InstancesWarning          = null
-    #         }
-    #         Instance = {
-    #           ApplicationLatencyP10     = null
-    #           ApplicationLatencyP50     = null
-    #           ApplicationLatencyP75     = null
-    #           ApplicationLatencyP85     = null
-    #           ApplicationLatencyP90     = null
-    #           ApplicationLatencyP95     = null
-    #           ApplicationLatencyP99     = null
-    #           "ApplicationLatencyP99.9" = null
-    #           ApplicationRequests2xx    = null
-    #           ApplicationRequests3xx    = null
-    #           ApplicationRequests4xx    = null
-    #           ApplicationRequests5xx    = null
-    #           ApplicationRequestsTotal  = null
-    #           CPUIdle                   = null
-    #           CPUPrivileged             = null
-    #           CPUUser                   = null
-    #           InstanceHealth            = null
-    #         }
-    #       }
-    #       Rules = {
-    #         Environment = {
-    #           Application = {
-    #             ApplicationRequests4xx = {
-    #               Enabled = true
-    #             }
-    #           }
-    #           ELB = {
-    #             ELBRequests4xx = {
-    #               Enabled = true
-    #             }
-    #           }
-    #         }
-    #       }
-    #       Version = 1
-    #     }
-    #   )
-    # },
+    {
+      name      = "ConfigDocument"
+      namespace = "aws:elasticbeanstalk:healthreporting:system"
+      value = jsonencode(
+        {
+          CloudWatchMetrics = {
+            Environment = {
+              ApplicationLatencyP10     = try(var.coudwatch_environment_metrics.ApplicationLatencyP10, null)
+              ApplicationLatencyP50     = try(var.coudwatch_environment_metrics.ApplicationLatencyP50, null)
+              ApplicationLatencyP75     = try(var.coudwatch_environment_metrics.ApplicationLatencyP75, null)
+              ApplicationLatencyP85     = try(var.coudwatch_environment_metrics.ApplicationLatencyP85, null)
+              ApplicationLatencyP90     = try(var.coudwatch_environment_metrics.ApplicationLatencyP90, null)
+              ApplicationLatencyP95     = try(var.coudwatch_environment_metrics.ApplicationLatencyP95, null)
+              ApplicationLatencyP99     = try(var.coudwatch_environment_metrics.ApplicationLatencyP99, null)
+              "ApplicationLatencyP99.9" = try(var.coudwatch_environment_metrics.ApplicationLatencyP99.9, null)
+              ApplicationRequests2xx    = try(var.coudwatch_environment_metrics.ApplicationRequests2xx, null)
+              ApplicationRequests3xx    = try(var.coudwatch_environment_metrics.ApplicationRequests3xx, null)
+              ApplicationRequests4xx    = try(var.coudwatch_environment_metrics.ApplicationRequests4xx, null)
+              ApplicationRequests5xx    = try(var.coudwatch_environment_metrics.ApplicationRequests5xx, null)
+              ApplicationRequestsTotal  = try(var.coudwatch_environment_metrics.ApplicationRequestsTotal, null)
+              InstancesDegraded         = try(var.coudwatch_environment_metrics.InstancesDegraded, null)
+              InstancesInfo             = try(var.coudwatch_environment_metrics.InstancesInfo, null)
+              InstancesNoData           = try(var.coudwatch_environment_metrics.InstancesNoData, null)
+              InstancesOk               = try(var.coudwatch_environment_metrics.InstancesOk, null)
+              InstancesPending          = try(var.coudwatch_environment_metrics.InstancesPending, null)
+              InstancesSevere           = try(var.coudwatch_environment_metrics.InstancesSevere, null)
+              InstancesUnknown          = try(var.coudwatch_environment_metrics.InstancesUnknown, null)
+              InstancesWarning          = try(var.coudwatch_environment_metrics.InstancesWarning, null)
+            }
+            Instance = {
+              ApplicationLatencyP10     = try(var.coudwatch_instance_metrics.ApplicationLatencyP10, null)
+              ApplicationLatencyP50     = try(var.coudwatch_instance_metrics.ApplicationLatencyP50, null)
+              ApplicationLatencyP75     = try(var.coudwatch_instance_metrics.ApplicationLatencyP75, null)
+              ApplicationLatencyP85     = try(var.coudwatch_instance_metrics.ApplicationLatencyP85, null)
+              ApplicationLatencyP90     = try(var.coudwatch_instance_metrics.ApplicationLatencyP90, null)
+              ApplicationLatencyP95     = try(var.coudwatch_instance_metrics.ApplicationLatencyP95, null)
+              ApplicationLatencyP99     = try(var.coudwatch_instance_metrics.ApplicationLatencyP99, null)
+              "ApplicationLatencyP99.9" = try(var.coudwatch_instance_metrics.ApplicationLatencyP99.9, null)
+              ApplicationRequests2xx    = try(var.coudwatch_instance_metrics.ApplicationRequests2xx, null)
+              ApplicationRequests3xx    = try(var.coudwatch_instance_metrics.ApplicationRequests3xx, null)
+              ApplicationRequests4xx    = try(var.coudwatch_instance_metrics.ApplicationRequests4xx, null)
+              ApplicationRequests5xx    = try(var.coudwatch_instance_metrics.ApplicationRequests5xx, null)
+              ApplicationRequestsTotal  = try(var.coudwatch_instance_metrics.ApplicationRequestsTotal, null)
+              CPUIdle                   = try(var.coudwatch_instance_metrics.CPUIdle, null)
+              CPUPrivileged             = try(var.coudwatch_instance_metrics.CPUPrivileged, null)
+              CPUUser                   = try(var.coudwatch_instance_metrics.CPUUser, null)
+              InstanceHealth            = try(var.coudwatch_instance_metrics.InstanceHealth, null)
+            }
+          }
+          Rules = {
+            Environment = {
+              Application = {
+                ApplicationRequests4xx = {
+                  Enabled = true
+                }
+              }
+              ELB = {
+                ELBRequests4xx = {
+                  Enabled = true
+                }
+              }
+            }
+          }
+          Version = 1
+        }
+      )
+    },
     {
       name      = "Cooldown"
       namespace = "aws:autoscaling:asg"


### PR DESCRIPTION
This pull request changes adds the option to add elastics beanstalk metrics to Instance and Environment.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...