### PR TITLE
🚀 RELEASE: Enable multiple hostnames per beanstalk environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The following resources will be created:
 | enable\_schedule | Enables schedule to shut down and start up instances outside business hours | `bool` | `false` | no |
 | environment | Name of this environment | `string` | `"dev"` | no |
 | hosted\_zone | Hosted zone to create the hostname | `string` | `""` | no |
-| hostname | Hostname to create on route53 pointing to the EB CNAME (leave empty to prevent creation) | `string` | `""` | no |
+| hostnames | Hostname to create on route53 pointing to the EB CNAME (leave empty to prevent creation) | `list(string)` | `[]` | no |
 | ignore\_iam\_account\_alias | Disables data source for iam\_account\_alias used on cloudwatch alarms | `bool` | `false` | no |
 | instance\_type\_1 | Instance type for ECS workers (first priority) | `any` | n/a | yes |
 | instance\_type\_2 | Instance type for ECS workers (second priority) | `any` | n/a | yes |

--- a/_variables.tf
+++ b/_variables.tf
@@ -74,8 +74,9 @@ variable "hosted_zone" {
   description = "Hosted zone to create the hostname"
 }
 
-variable "hostname" {
-  default     = ""
+variable "hostnames" {
+  type        = list(string)
+  default     = []
   description = "Hostname to create on route53 pointing to the EB CNAME (leave empty to prevent creation)"
 }
 

--- a/route53-record.tf
+++ b/route53-record.tf
@@ -1,13 +1,13 @@
 data "aws_route53_zone" "selected" {
-  count = var.hostname != "" ? 1 : 0
+  count = length(var.hostnames) > 0 ? 1 : 0
   name  = var.hosted_zone
 }
 
 resource "aws_route53_record" "hostname" {
-  count = var.hostname != "" ? 1 : 0
+  for_each = toset(var.hostnames)
 
   zone_id = data.aws_route53_zone.selected.*.zone_id[0]
-  name    = var.hostname
+  name    = each.key
   type    = "CNAME"
   ttl     = "300"
   records = tolist([aws_elastic_beanstalk_environment.env.cname])


### PR DESCRIPTION
This pull requests adds the option to create multiple route 53 record names pointing to the same beanstalk environment. 

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.
