### PR TITLE
🐛 FIX: Eb environment HealthCheckPath beeing declared twice

### DIFF
--- a/eb.tf
+++ b/eb.tf
@@ -16,11 +16,6 @@ locals {
       value     = "20"
     },
     {
-      name      = "HealthCheckPath"
-      namespace = "aws:elasticbeanstalk:environment:process:default"
-      value     = "/"
-    },
-    {
       name      = "HealthCheckTimeout"
       namespace = "aws:elasticbeanstalk:environment:process:default"
       value     = "5"


### PR DESCRIPTION
The `HealthCheckPath` parameter at beanstalk environment resource was being declared twice. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.