### PR TITLE
Add support for dotnet core linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The following resources will be created:
 | deployment\_timeout | Number of seconds to wait for an instance to complete executing commands | `number` | `600` | no |
 | description | Short description of the Environment | `string` | `""` | no |
 | eb\_application\_name | EB application name (empty value will create an application) | `string` | `""` | no |
+| eb\_platform | EB platform name (empty value will default to .NET Framework on windows). The following values are supported: `dotnet`, `dotnetcorelinux` | `string` | `"dotnet"` | no |
 | eb\_solution\_stack\_name | Stack name passed to ElasticBeanstalk | `any` | n/a | yes |
 | eb\_tier | Elastic Beanstalk Environment tier, 'WebServer' or 'Worker' | `string` | `"WebServer"` | no |
 | eb\_version\_label | Elastic Beanstalk Application version to deploy | `string` | `""` | no |

--- a/_variables.tf
+++ b/_variables.tf
@@ -13,6 +13,11 @@ variable "environment" {
   description = "Name of this environment"
 }
 
+variable "eb_platform" {
+  default     = "dotnet"
+  description = "Platform type, e.g. 'dotnet', 'dotnetcorelinux'"
+}
+
 variable "eb_solution_stack_name" {
   description = "Stack name passed to ElasticBeanstalk"
 }

--- a/eb.tf
+++ b/eb.tf
@@ -163,16 +163,6 @@ locals {
       value     = "enhanced"
     },
     {
-      name      = "Enable 32-bit Applications"
-      namespace = "aws:elasticbeanstalk:container:dotnet:apppool"
-      value     = "False"
-    },
-    {
-      name      = "Target Runtime"
-      namespace = "aws:elasticbeanstalk:container:dotnet:apppool"
-      value     = "4.0"
-    },
-    {
       name      = "InstanceRefreshEnabled"
       namespace = "aws:elasticbeanstalk:managedactions:platformupdate"
       value     = var.instance_refresh_enabled
@@ -196,6 +186,19 @@ locals {
       name      = "XRayEnabled"
       namespace = "aws:elasticbeanstalk:xray"
       value     = "true"
+    },
+  ]
+  
+  eb_dotnet_settings = [
+    {
+      name      = "Enable 32-bit Applications"
+      namespace = "aws:elasticbeanstalk:container:dotnet:apppool"
+      value     = "False"
+    },
+    {
+      name      = "Target Runtime"
+      namespace = "aws:elasticbeanstalk:container:dotnet:apppool"
+      value     = "4.0"
     },
   ]
 
@@ -591,12 +594,13 @@ locals {
   # If the tier is "WebServer" add the elb_settings, otherwise exclude them
   elb_settings_final = var.eb_tier == "WebServer" ? concat(local.elb_settings_nlb, local.elb_settings_alb, local.elb_settings_shared_alb) : []
 
+  eb_defaults = var.eb_platform == "dotnet" ? concat(local.eb_default_settings, local.eb_dotnet_settings) : local.eb_default_settings
+  
   # Grab all elastic beanstalk settings
-  eb_settings = concat(local.eb_default_settings, local.eb_vpc, local.eb_asg, local.eb_launch_config, local.eb_cloudwatch)
+  eb_settings = concat(local.eb_defaults, local.eb_vpc, local.eb_asg, local.eb_launch_config, local.eb_cloudwatch)
 
   # Put all settings together
   eb_settings_final = concat(local.eb_settings, local.elb_settings_final)
-
 }
 
 resource "aws_elastic_beanstalk_application" "app" {

--- a/eb.tf
+++ b/eb.tf
@@ -76,16 +76,6 @@ locals {
       value     = "80"
     },
     {
-      name      = "LargerInstanceTypeRequired"
-      namespace = "aws:cloudformation:template:parameter"
-      value     = "true"
-    },
-    {
-      name      = "SystemType"
-      namespace = "aws:cloudformation:template:parameter"
-      value     = "enhanced"
-    },
-    {
       name      = "ConfigDocument"
       namespace = "aws:elasticbeanstalk:healthreporting:system"
       value = jsonencode(
@@ -190,6 +180,16 @@ locals {
   ]
   
   eb_dotnet_settings = [
+    {
+      name      = "LargerInstanceTypeRequired"
+      namespace = "aws:cloudformation:template:parameter"
+      value     = "true"
+    },
+    {
+      name      = "SystemType"
+      namespace = "aws:cloudformation:template:parameter"
+      value     = "enhanced"
+    },
     {
       name      = "Enable 32-bit Applications"
       namespace = "aws:elasticbeanstalk:container:dotnet:apppool"

--- a/eb.tf
+++ b/eb.tf
@@ -119,7 +119,7 @@ locals {
               ApplicationRequests5xx    = try(var.coudwatch_instance_metrics.ApplicationRequests5xx, null)
               ApplicationRequestsTotal  = try(var.coudwatch_instance_metrics.ApplicationRequestsTotal, null)
               CPUIdle                   = try(var.coudwatch_instance_metrics.CPUIdle, null)
-              (var.eb_platform == "dotnet" ? "CPUPrivileged" : "CPUSystem")
+              "${var.eb_platform == "dotnet" ? "CPUPrivileged" : "CPUSystem"}"
                                         = try(var.coudwatch_instance_metrics[var.eb_platform == "dotnet" ? "CPUPrivileged" : "CPUSystem"], null)
               CPUUser                   = try(var.coudwatch_instance_metrics.CPUUser, null)
               InstanceHealth            = try(var.coudwatch_instance_metrics.InstanceHealth, null)

--- a/eb.tf
+++ b/eb.tf
@@ -119,8 +119,7 @@ locals {
               ApplicationRequests5xx    = try(var.coudwatch_instance_metrics.ApplicationRequests5xx, null)
               ApplicationRequestsTotal  = try(var.coudwatch_instance_metrics.ApplicationRequestsTotal, null)
               CPUIdle                   = try(var.coudwatch_instance_metrics.CPUIdle, null)
-              "${var.eb_platform == "dotnet" ? "CPUPrivileged" : "CPUSystem"}"
-                                        = try(var.coudwatch_instance_metrics[var.eb_platform == "dotnet" ? "CPUPrivileged" : "CPUSystem"], null)
+              "${var.eb_platform == "dotnet" ? "CPUPrivileged" : "CPUSystem"}" = try(var.coudwatch_instance_metrics[var.eb_platform == "dotnet" ? "CPUPrivileged" : "CPUSystem"], null)
               CPUUser                   = try(var.coudwatch_instance_metrics.CPUUser, null)
               InstanceHealth            = try(var.coudwatch_instance_metrics.InstanceHealth, null)
             }

--- a/eb.tf
+++ b/eb.tf
@@ -119,7 +119,8 @@ locals {
               ApplicationRequests5xx    = try(var.coudwatch_instance_metrics.ApplicationRequests5xx, null)
               ApplicationRequestsTotal  = try(var.coudwatch_instance_metrics.ApplicationRequestsTotal, null)
               CPUIdle                   = try(var.coudwatch_instance_metrics.CPUIdle, null)
-              CPUPrivileged             = try(var.coudwatch_instance_metrics.CPUPrivileged, null)
+              "${var.eb_platform == 'dotnet' ? 'CPUPrivileged' : 'CPUSystem'}"
+                                        = try(var.coudwatch_instance_metrics["${var.eb_platform == 'dotnet' ? 'CPUPrivileged' : 'CPUSystem'}"], null)
               CPUUser                   = try(var.coudwatch_instance_metrics.CPUUser, null)
               InstanceHealth            = try(var.coudwatch_instance_metrics.InstanceHealth, null)
             }

--- a/eb.tf
+++ b/eb.tf
@@ -119,8 +119,8 @@ locals {
               ApplicationRequests5xx    = try(var.coudwatch_instance_metrics.ApplicationRequests5xx, null)
               ApplicationRequestsTotal  = try(var.coudwatch_instance_metrics.ApplicationRequestsTotal, null)
               CPUIdle                   = try(var.coudwatch_instance_metrics.CPUIdle, null)
-              "${var.eb_platform == 'dotnet' ? 'CPUPrivileged' : 'CPUSystem'}"
-                                        = try(var.coudwatch_instance_metrics["${var.eb_platform == 'dotnet' ? 'CPUPrivileged' : 'CPUSystem'}"], null)
+              (var.eb_platform == "dotnet" ? "CPUPrivileged" : "CPUSystem")
+                                        = try(var.coudwatch_instance_metrics[var.eb_platform == "dotnet" ? "CPUPrivileged" : "CPUSystem"], null)
               CPUUser                   = try(var.coudwatch_instance_metrics.CPUUser, null)
               InstanceHealth            = try(var.coudwatch_instance_metrics.InstanceHealth, null)
             }


### PR DESCRIPTION
A few simple changes to allow the .NET Core Linux EB Platform to be used with this template. Specifying 'eb_platform' (optional) accepts either 'dotnet' (existing functionality and default) or 'dotnetcorelinux'. The latter then prevents the inclusion of the Windows .NET EB platform-specific settings, as well as using 'CPUSystem' (Linux only) instead of 'CPUPrivileged' (Windows only) for the Cloudwatch config document.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

This allows a moderate step from eb-windows towards Linux-based solutions. Have tested in our environment and produced a working starter Linux .NET Core application.