### PR TITLE
Fix for Linux EB instances always detecting changes

### DIFF
--- a/eb.tf
+++ b/eb.tf
@@ -78,7 +78,8 @@ locals {
     {
       name      = "ConfigDocument"
       namespace = "aws:elasticbeanstalk:healthreporting:system"
-      value = jsonencode(
+      value = var.eb_platform == "dotnet"
+        ? jsonencode(
         {
           CloudWatchMetrics = {
             Environment = {
@@ -119,7 +120,70 @@ locals {
               ApplicationRequests5xx    = try(var.coudwatch_instance_metrics.ApplicationRequests5xx, null)
               ApplicationRequestsTotal  = try(var.coudwatch_instance_metrics.ApplicationRequestsTotal, null)
               CPUIdle                   = try(var.coudwatch_instance_metrics.CPUIdle, null)
-              "${var.eb_platform == "dotnet" ? "CPUPrivileged" : "CPUSystem"}" = try(var.coudwatch_instance_metrics[var.eb_platform == "dotnet" ? "CPUPrivileged" : "CPUSystem"], null)
+              CPUPrivileged             = try(var.coudwatch_instance_metrics.CPUPrivileged, null)
+              CPUUser                   = try(var.coudwatch_instance_metrics.CPUUser, null)
+              InstanceHealth            = try(var.coudwatch_instance_metrics.InstanceHealth, null)
+            }
+          }
+          Rules = {
+            Environment = {
+              Application = {
+                ApplicationRequests4xx = {
+                  Enabled = true
+                }
+              }
+              ELB = {
+                ELBRequests4xx = {
+                  Enabled = true
+                }
+              }
+            }
+          }
+          Version = 1
+        }
+      )
+      : jsonencode(
+        {
+          CloudWatchMetrics = {
+            Environment = {
+              ApplicationLatencyP10     = try(var.coudwatch_environment_metrics.ApplicationLatencyP10, null)
+              ApplicationLatencyP50     = try(var.coudwatch_environment_metrics.ApplicationLatencyP50, null)
+              ApplicationLatencyP75     = try(var.coudwatch_environment_metrics.ApplicationLatencyP75, null)
+              ApplicationLatencyP85     = try(var.coudwatch_environment_metrics.ApplicationLatencyP85, null)
+              ApplicationLatencyP90     = try(var.coudwatch_environment_metrics.ApplicationLatencyP90, null)
+              ApplicationLatencyP95     = try(var.coudwatch_environment_metrics.ApplicationLatencyP95, null)
+              ApplicationLatencyP99     = try(var.coudwatch_environment_metrics.ApplicationLatencyP99, null)
+              "ApplicationLatencyP99.9" = try(var.coudwatch_environment_metrics.ApplicationLatencyP99.9, null)
+              ApplicationRequests2xx    = try(var.coudwatch_environment_metrics.ApplicationRequests2xx, null)
+              ApplicationRequests3xx    = try(var.coudwatch_environment_metrics.ApplicationRequests3xx, null)
+              ApplicationRequests4xx    = try(var.coudwatch_environment_metrics.ApplicationRequests4xx, null)
+              ApplicationRequests5xx    = try(var.coudwatch_environment_metrics.ApplicationRequests5xx, null)
+              ApplicationRequestsTotal  = try(var.coudwatch_environment_metrics.ApplicationRequestsTotal, null)
+              InstancesDegraded         = try(var.coudwatch_environment_metrics.InstancesDegraded, null)
+              InstancesInfo             = try(var.coudwatch_environment_metrics.InstancesInfo, null)
+              InstancesNoData           = try(var.coudwatch_environment_metrics.InstancesNoData, null)
+              InstancesOk               = try(var.coudwatch_environment_metrics.InstancesOk, null)
+              InstancesPending          = try(var.coudwatch_environment_metrics.InstancesPending, null)
+              InstancesSevere           = try(var.coudwatch_environment_metrics.InstancesSevere, null)
+              InstancesUnknown          = try(var.coudwatch_environment_metrics.InstancesUnknown, null)
+              InstancesWarning          = try(var.coudwatch_environment_metrics.InstancesWarning, null)
+            }
+            Instance = {
+              ApplicationLatencyP10     = try(var.coudwatch_instance_metrics.ApplicationLatencyP10, null)
+              ApplicationLatencyP50     = try(var.coudwatch_instance_metrics.ApplicationLatencyP50, null)
+              ApplicationLatencyP75     = try(var.coudwatch_instance_metrics.ApplicationLatencyP75, null)
+              ApplicationLatencyP85     = try(var.coudwatch_instance_metrics.ApplicationLatencyP85, null)
+              ApplicationLatencyP90     = try(var.coudwatch_instance_metrics.ApplicationLatencyP90, null)
+              ApplicationLatencyP95     = try(var.coudwatch_instance_metrics.ApplicationLatencyP95, null)
+              ApplicationLatencyP99     = try(var.coudwatch_instance_metrics.ApplicationLatencyP99, null)
+              "ApplicationLatencyP99.9" = try(var.coudwatch_instance_metrics.ApplicationLatencyP99.9, null)
+              ApplicationRequests2xx    = try(var.coudwatch_instance_metrics.ApplicationRequests2xx, null)
+              ApplicationRequests3xx    = try(var.coudwatch_instance_metrics.ApplicationRequests3xx, null)
+              ApplicationRequests4xx    = try(var.coudwatch_instance_metrics.ApplicationRequests4xx, null)
+              ApplicationRequests5xx    = try(var.coudwatch_instance_metrics.ApplicationRequests5xx, null)
+              ApplicationRequestsTotal  = try(var.coudwatch_instance_metrics.ApplicationRequestsTotal, null)
+              CPUIdle                   = try(var.coudwatch_instance_metrics.CPUIdle, null)
+              CPUSystem                 = try(var.coudwatch_instance_metricsCPUSystem, null)
               CPUUser                   = try(var.coudwatch_instance_metrics.CPUUser, null)
               InstanceHealth            = try(var.coudwatch_instance_metrics.InstanceHealth, null)
             }

--- a/eb.tf
+++ b/eb.tf
@@ -78,7 +78,7 @@ locals {
     {
       name      = "ConfigDocument"
       namespace = "aws:elasticbeanstalk:healthreporting:system"
-      value = var.eb_platform == "dotnet"
+      value = (var.eb_platform == "dotnet"
         ? jsonencode(
         {
           CloudWatchMetrics = {
@@ -204,7 +204,7 @@ locals {
           }
           Version = 1
         }
-      )
+      ))
     },
     {
       name      = "HealthCheckSuccessThreshold"

--- a/eb.tf
+++ b/eb.tf
@@ -183,7 +183,7 @@ locals {
               ApplicationRequests5xx    = try(var.coudwatch_instance_metrics.ApplicationRequests5xx, null)
               ApplicationRequestsTotal  = try(var.coudwatch_instance_metrics.ApplicationRequestsTotal, null)
               CPUIdle                   = try(var.coudwatch_instance_metrics.CPUIdle, null)
-              CPUSystem                 = try(var.coudwatch_instance_metricsCPUSystem, null)
+              CPUSystem                 = try(var.coudwatch_instance_metrics.CPUSystem, null)
               CPUUser                   = try(var.coudwatch_instance_metrics.CPUUser, null)
               InstanceHealth            = try(var.coudwatch_instance_metrics.InstanceHealth, null)
             }


### PR DESCRIPTION
This fixes Linux Elastic Beanstalk instances always detecting changes in Terraform due to a jsonencode that has conditional contents.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

The solution (although not as elegant) is to switch between two nearly identical jsonencode calls that have the final contents in each so it can be compared.