### PR TITLE
Fix support for network load balancers

### DIFF
--- a/alb-rule-redirect.tf
+++ b/alb-rule-redirect.tf
@@ -1,11 +1,12 @@
 data "aws_lb_listener" "selected_80" {
-  load_balancer_arn = aws_elastic_beanstalk_environment.env.load_balancers[0]
+  count        = var.eb_tier == "WebServer" && var.environment_type == "LoadBalanced" && var.loadbalancer_type != "network" && !var.loadbalancer_is_shared ? 1 : 0
+  load_balancer_arn = aws_elastic_beanstalk_environment.env.load_balancers[count.index]
   port              = 80
 }
 
 resource "aws_lb_listener_rule" "redirect_http_to_https" {
   count        = var.eb_tier == "WebServer" && var.environment_type == "LoadBalanced" && var.loadbalancer_type != "network" && !var.loadbalancer_is_shared ? 1 : 0
-  listener_arn = data.aws_lb_listener.selected_80.arn
+  listener_arn = data.aws_lb_listener.selected_80[count.index].arn
 
   action {
     type = "redirect"

--- a/eb.tf
+++ b/eb.tf
@@ -68,7 +68,7 @@ locals {
     {
       name      = "InstancePort"
       namespace = "aws:cloudformation:template:parameter"
-      value     = "80"
+      value     = "${var.application_port}"
     },
     {
       name      = "ConfigDocument"
@@ -494,11 +494,6 @@ locals {
   ]
 
   generic_alb_settings = [
-    {
-      name      = "SecurityGroups"
-      namespace = "aws:elbv2:loadbalancer"
-      value     = join(",", sort(var.loadbalancer_security_groups))
-    }
   ]
 
   shared_alb_settings = [
@@ -645,6 +640,11 @@ locals {
       name      = "UnhealthyThresholdCount"
       namespace = "aws:elasticbeanstalk:environment:process:default"
       value     = var.healthcheck_unhealthy_threshold_count
+    },
+    {
+      name      = "SecurityGroups"
+      namespace = "aws:elbv2:loadbalancer"
+      value     = join(",", sort(var.loadbalancer_security_groups))
     },
   ]
 

--- a/eb.tf
+++ b/eb.tf
@@ -573,6 +573,21 @@ locals {
       name      = "HealthCheckTimeout"
       namespace = "aws:elasticbeanstalk:environment:process:default"
       value     = var.healthcheck_timeout
+    },
+    {
+      name      = "StickinessEnabled"
+      namespace = "aws:elasticbeanstalk:environment:process:default"
+      value     = var.stickiness_enabled
+    },
+    {
+      name      = "StickinessLBCookieDuration"
+      namespace = "aws:elasticbeanstalk:environment:process:default"
+      value     = var.stickiness_expiration
+    },
+    {
+      name      = "StickinessType"
+      namespace = "aws:elasticbeanstalk:environment:process:default"
+      value     = "lb_cookie"
     }
   ]
 
@@ -635,21 +650,6 @@ locals {
       name      = "UnhealthyThresholdCount"
       namespace = "aws:elasticbeanstalk:environment:process:default"
       value     = var.healthcheck_unhealthy_threshold_count
-    },
-    {
-      name      = "StickinessEnabled"
-      namespace = "aws:elasticbeanstalk:environment:process:default"
-      value     = var.stickiness_enabled
-    },
-    {
-      name      = "StickinessLBCookieDuration"
-      namespace = "aws:elasticbeanstalk:environment:process:default"
-      value     = var.stickiness_expiration
-    },
-    {
-      name      = "StickinessType"
-      namespace = "aws:elasticbeanstalk:environment:process:default"
-      value     = "lb_cookie"
     },
   ]
 

--- a/eb.tf
+++ b/eb.tf
@@ -68,7 +68,7 @@ locals {
     {
       name      = "InstancePort"
       namespace = "aws:cloudformation:template:parameter"
-      value     = "${var.application_port}"
+      value     = "${var.loadbalancer_type == "network" ? var.application_port : 80}"
     },
     {
       name      = "ConfigDocument"

--- a/eb.tf
+++ b/eb.tf
@@ -494,6 +494,11 @@ locals {
   ]
 
   generic_alb_settings = [
+    {
+      name      = "SecurityGroups"
+      namespace = "aws:elbv2:loadbalancer"
+      value     = join(",", sort(var.loadbalancer_security_groups))
+    }
   ]
 
   shared_alb_settings = [
@@ -640,12 +645,7 @@ locals {
       name      = "UnhealthyThresholdCount"
       namespace = "aws:elasticbeanstalk:environment:process:default"
       value     = var.healthcheck_unhealthy_threshold_count
-    },
-    {
-      name      = "SecurityGroups"
-      namespace = "aws:elbv2:loadbalancer"
-      value     = join(",", sort(var.loadbalancer_security_groups))
-    },
+    }
   ]
 
   alb_settings = var.loadbalancer_access_logs_s3_enabled ? concat(local.alb_default_settings, local.alb_logs_settings) : local.alb_default_settings

--- a/eb.tf
+++ b/eb.tf
@@ -68,7 +68,7 @@ locals {
     {
       name      = "InstancePort"
       namespace = "aws:cloudformation:template:parameter"
-      value     = "${var.loadbalancer_type == "network" ? var.application_port : 80}"
+      value     = "80"
     },
     {
       name      = "ConfigDocument"

--- a/eb.tf
+++ b/eb.tf
@@ -16,11 +16,6 @@ locals {
       value     = "20"
     },
     {
-      name      = "HealthCheckTimeout"
-      namespace = "aws:elasticbeanstalk:environment:process:default"
-      value     = "5"
-    },
-    {
       name      = "RollbackLaunchOnFailure"
       namespace = "aws:elasticbeanstalk:control"
       value     = "false"

--- a/eb.tf
+++ b/eb.tf
@@ -453,6 +453,11 @@ locals {
       namespace = "aws:autoscaling:launchconfiguration"
       value     = "5 minute"
     },
+    {
+      name      = "DisableIMDSv1"
+      namespace = "aws:autoscaling:launchconfiguration"
+      value     = "true"
+    },
   ]
 
   eb_cloudwatch = [


### PR DESCRIPTION
Network load balancer support for the eb windows module was broken. These changes restore the ability to sucessfully use a network load balancer for an elastic beanstalk environment.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [X] I have read the CONTRIBUTING.md doc.
- [X] I have added necessary documentation (if appropriate).
- [X] Any dependent changes have been merged and published in downstream modules.

## Further comments
* Reading the load balancer listener fails when using a network load balancer, so count condition added
* A number of settings are placed in areas of the eb config that then include them for network load balancers, but the settings are not supported. These have been moved to appropriate locations.