### PR TITLE
fix ci/cd deployments and new output for cname of environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ The following resources will be created:
 | eb\_aws\_security\_group\_id | n/a |
 | eb\_environment\_id | n/a |
 | eb\_load\_balancers | n/a |
+| eb\_environment\_cname | CNAME of the environment for more complex DNS scenarios |
 | iam\_role\_eb\_arn | ARN for EB IAM role |
 | iam\_role\_eb\_name | Name of EB IAM role |
 | ssm\_association\_join\_domain\_automation | n/a |

--- a/_outputs.tf
+++ b/_outputs.tf
@@ -23,3 +23,7 @@ output "eb_load_balancers" {
 output "eb_aws_security_group_id" {
   value = try(aws_security_group.eb[0].id, "")
 }
+
+output "eb_environment_cname" {
+  value = try(aws_elastic_beanstalk_environment.env.cname, "")
+}

--- a/_variables.tf
+++ b/_variables.tf
@@ -112,7 +112,7 @@ variable "eb_tier" {
 
 variable "eb_version_label" {
   type        = string
-  default     = "default"
+  default     = ""
   description = "Elastic Beanstalk Application version to deploy"
 }
 


### PR DESCRIPTION
The current latest release always pushes `default` as the application version, rather than leaving it with whatever is currently deployed via CI/CD. This change reverts that behaviour (consumers can still manually set `default`). The CNAME for an EB environment is also now available as an output for use cases where you want to set up your own DNS (and avoid the overhead of having to perform a read to get the data required).

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.
